### PR TITLE
Proposal: be more colorful for live and premiere shows

### DIFF
--- a/app/src/main/java/de/metzgore/beansplan/shared/ShowViewModel.kt
+++ b/app/src/main/java/de/metzgore/beansplan/shared/ShowViewModel.kt
@@ -35,8 +35,14 @@ OnReminderButtonClickListener?) {
             if (showWithReminder.show.length > 3600) "H 'h' mm 'min'" else "m 'min'")
 
     fun getBackground(context: Context): Drawable? {
-        return if (showWithReminder.show.isRunning) ContextCompat.getDrawable(context, R.drawable.border_current_show) else
-            null
+        if (showWithReminder.show.isRunning)
+            return ContextCompat.getDrawable(context, R.drawable.border_current_show)
+
+        return when (showWithReminder.show.type) {
+            ShowResponse.Type.LIVE -> ContextCompat.getDrawable(context, R.drawable.border_live_show)
+            ShowResponse.Type.PREMIERE -> ContextCompat.getDrawable(context, R.drawable.border_premiere_show)
+            else -> null
+        }
     }
 
     fun getStartTimeFormatted(context: Context): String {

--- a/app/src/main/java/de/metzgore/beansplan/shared/ShowViewModel.kt
+++ b/app/src/main/java/de/metzgore/beansplan/shared/ShowViewModel.kt
@@ -45,6 +45,14 @@ OnReminderButtonClickListener?) {
         }
     }
 
+    fun getTypeTextColor(context: Context): Int {
+        return when (showWithReminder.show.type) {
+            ShowResponse.Type.LIVE -> ContextCompat.getColor(context, R.color.live)
+            ShowResponse.Type.PREMIERE -> ContextCompat.getColor(context, R.color.premiere)
+            else -> 0
+        }
+    }
+
     fun getStartTimeFormatted(context: Context): String {
         return DateUtils.formatDateTime(context, showWithReminder.show.timeStart.time, DateUtils.FORMAT_SHOW_TIME)
     }

--- a/app/src/main/res/drawable/border_live_show.xml
+++ b/app/src/main/res/drawable/border_live_show.xml
@@ -1,0 +1,19 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape
+            android:shape="rectangle">
+            <solid
+                android:color="@color/live"/>
+        </shape>
+    </item>
+    <item
+        android:left="5dp"
+        android:right="5dp">
+
+        <shape
+            android:shape="rectangle">
+            <solid
+                android:color="@color/white"/>
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/border_premiere_show.xml
+++ b/app/src/main/res/drawable/border_premiere_show.xml
@@ -1,0 +1,19 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape
+            android:shape="rectangle">
+            <solid
+                android:color="@color/premiere"/>
+        </shape>
+    </item>
+    <item
+        android:left="5dp"
+        android:right="5dp">
+
+        <shape
+            android:shape="rectangle">
+            <solid
+                android:color="@color/white"/>
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/list_item_show.xml
+++ b/app/src/main/res/layout/list_item_show.xml
@@ -110,7 +110,7 @@
                     android:layout_height="wrap_content"
                     android:text="@{viewModel.typeFormatted}"
                     android:textAlignment="textEnd"
-                    android:textColor="@color/colorAccent"
+                    android:textColor="@{viewModel.getTypeTextColor(context)}"
                     tools:text="PREMIERE" />
 
                 <LinearLayout

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,6 @@
     <color name="colorAccent">#009688</color>
     <color name="white">#FFFFFF</color>
     <color name="red">#D50000</color>
-    <color name="live">#ff217c</color>
-    <color name="premiere">#1893b2</color>
+    <color name="live">#DB5E91</color>
+    <color name="premiere">#1893B2</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,4 +6,6 @@
     <color name="colorAccent">#009688</color>
     <color name="white">#FFFFFF</color>
     <color name="red">#D50000</color>
+    <color name="live">#ff217c</color>
+    <color name="premiere">#1893b2</color>
 </resources>


### PR DESCRIPTION
I think the LIVE and PREMIERE texts are not salient enough in order to immediately see which shows are new on a day.
Therefore I made a little change which marks live and premiere shows with a small colored border, similar to the currently running show.